### PR TITLE
Add missing dependencies

### DIFF
--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -11,3 +11,5 @@ dependencies:
   - gfortran
   - nlopt
   - cerf
+  - matplotlib
+  - wxpython


### PR DESCRIPTION
Request from @cheng-hung:
> Some packages, such as wxpython and matplotlib, are missing so the GUI doesn't work.